### PR TITLE
[FEAT] 구글 OAuth 로컬 로그인, 로그아웃, 인가 구현

### DIFF
--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -4,10 +4,11 @@ import My from '@/pages/my';
 import Setting from '@/pages/setting';
 import Layout from '../ui/Layout';
 import { useCookies } from 'react-cookie';
+import GoogleCallback from '@/pages/callback/google';
 
 function ProtectedRoute({ element }: { element: JSX.Element }) {
-  const [cookies] = useCookies();
-  return cookies.access_token ? element : <Navigate to="/login" />;
+  const [cookies] = useCookies(['access_token']);
+  return cookies.access_token && cookies.access_token !== 'undefined' ? element : <Navigate to="/login" />;
 }
 
 const router = createBrowserRouter([
@@ -16,8 +17,12 @@ const router = createBrowserRouter([
     element: <Login />,
   },
   {
+    path: '/auth/google/callback',
+    element: <GoogleCallback />,
+  },
+  {
     path: '/',
-    element: <Layout />,
+    element: <ProtectedRoute element={<Layout />} />,
     children: [
       {
         path: '',

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,6 +1,30 @@
 import { axiosInstance } from '@/shared/api/axiosInstance';
 
+interface Code {
+  code: string | false | null;
+}
+
+interface GoogleCallbackData {
+  success: boolean;
+  tokens: {
+    access: string;
+    refresh: string;
+  };
+  user: {
+    email: string;
+  };
+}
+
+export async function getGoogleAuth({ code }: Code): Promise<{ data: GoogleCallbackData } | undefined> {
+  const response = await axiosInstance.get<GoogleCallbackData>(`/api/auth/google/callback/local?code=${code}`);
+  return { data: response.data };
+}
+
 export async function logout() {
-  const response = await axiosInstance.get('/api/auth/logout');
-  return response.data;
+  try {
+    const response = await axiosInstance.get('/api/auth/logout');
+    return response.data;
+  } catch (error) {
+    console.error('Logout failed:', error);
+  }
 }

--- a/src/features/auth/model/useAuth.ts
+++ b/src/features/auth/model/useAuth.ts
@@ -1,25 +1,20 @@
 import { useState } from 'react';
 import { useCookies } from 'react-cookie';
-import { logout } from '../api/authApi';
+//import { logout } from '../api/authApi';
 
 export default function useAuth() {
   const [isAuth, setIsAuth] = useState(false);
-  const [cookies, removeCookie] = useCookies();
+  const [cookies, removeCookies] = useCookies();
 
   function handleLogin() {
     if (cookies.access_token) setIsAuth(true);
   }
 
-  async function handleLogout() {
-    try {
-      removeCookie('access_token', { path: '/' });
-      removeCookie('refresh_token', { path: '/' });
-      setIsAuth(false);
-      console.log('Attempting logout API call');
-      await logout();
-    } catch (error) {
-      console.error('Logout failed:', error);
-    }
+  function handleLogout() {
+    removeCookies('access_token', undefined, { path: '/' });
+    removeCookies('refresh_token', undefined, { path: '/' });
+    setIsAuth(false);
+    //logout();
   }
 
   return {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -9,7 +9,7 @@ export default function Login() {
       <p className="font-bold pt-2">자동 포스팅 수익화를 현실로</p>
       <Button
         className="w-72 mt-20 px-4 flex items-center gap-10 h-12 bg-transparent border border-gray-300"
-        href={`${API_BASE_URL}/api/auth/google/login`}>
+        href={`${API_BASE_URL}/api/auth/google/login/local`}>
         <img src={googleLogo} alt="Google Logo" className="rounded-full" />
         <p className="pr-8">Google로 계속하기</p>
       </Button>

--- a/src/pages/callback/google.tsx
+++ b/src/pages/callback/google.tsx
@@ -1,0 +1,37 @@
+import { getGoogleAuth } from '@/features/auth/api/authApi';
+import useFetch from '@/shared/model/useFetch';
+import { useCallback, useEffect } from 'react';
+import { useCookies } from 'react-cookie';
+import { useNavigate } from 'react-router-dom';
+
+const code = typeof window !== 'undefined' && new URL(window.location.toString()).searchParams.get('code');
+
+export default function GoogleCallback() {
+  const [, setCookie] = useCookies();
+  const navigate = useNavigate();
+  const { data, execute } = useFetch(() => getGoogleAuth({ code }));
+
+  const fetchData = useCallback(() => {
+    if (!data) {
+      execute();
+    }
+  }, [data, execute]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    if (data) {
+      if (data.success) {
+        setCookie('access_token', data.tokens.access, { path: '/' });
+        setCookie('refresh_token', data.tokens.refresh, { path: '/' });
+        navigate('/my');
+      } else {
+        navigate('/login');
+      }
+    }
+  }, [data, navigate, setCookie]);
+
+  return <></>;
+}

--- a/src/shared/model/useFetch.ts
+++ b/src/shared/model/useFetch.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react';
+
+interface FetchResponse<T> {
+  loading: boolean;
+  error: boolean | undefined;
+  data: T | null;
+  execute: () => void;
+}
+
+const useFetch = <T>(fetchFunction: () => Promise<{ data: T } | undefined>): FetchResponse<T> => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<boolean | undefined>(undefined);
+  const [data, setData] = useState<T | null>(null);
+
+  const useEffectOnce = (callback: () => void) => {
+    useEffect(() => {
+      callback();
+    }, []);
+  };
+
+  const execute = async () => {
+    if (loading) return;
+    if (data) return;
+
+    setLoading(true);
+    setError(undefined);
+
+    try {
+      const response = await fetchFunction();
+
+      if (response && response.data) {
+        setData(response.data);
+      } else {
+        setData(null);
+      }
+    } catch (error) {
+      setError(true);
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffectOnce(execute);
+  return { execute, loading, error, data };
+};
+
+export default useFetch;


### PR DESCRIPTION
## 구현 상황
- OAuth 인증 시 쿠키를 서버에서 생성하고 관리했을 때 요청 보낼 시 cors 에러가 계속 발생
- 이를 해결하기 위해 cookie를 클라이언트에서 관리하는 로직으로 변경하고, redirectUrl을 로컬과 배포로 분리