### PR TITLE
[FIX] 비로그인 시 무한 요청 수정

### DIFF
--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -7,8 +7,8 @@ import { useCookies } from 'react-cookie';
 import GoogleCallback from '@/pages/googleCallback';
 
 function ProtectedRoute({ element }: { element: JSX.Element }) {
-  const [cookies] = useCookies(['access_token']);
-  return cookies.access_token && cookies.access_token !== 'undefined' ? element : <Navigate to="/login" />;
+  const [cookies] = useCookies(['accessToken']);
+  return cookies.accessToken && cookies.accessToken !== 'undefined' ? element : <Navigate to="/login" />;
 }
 
 const router = createBrowserRouter([

--- a/src/features/auth/model/useAuth.ts
+++ b/src/features/auth/model/useAuth.ts
@@ -1,23 +1,34 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 
 export default function useAuth() {
   const [isAuth, setIsAuth] = useState(false);
-  const [cookies, removeCookies] = useCookies();
+  const [cookies, setCookies, removeCookies] = useCookies(['accessToken', 'refreshToken']);
 
-  function handleLogin() {
-    if (cookies.access_token) setIsAuth(true);
+  useEffect(() => {
+    if (cookies.accessToken && cookies.accessToken !== 'undefined') {
+      setIsAuth(true);
+    } else {
+      setIsAuth(false);
+    }
+  }, [cookies.accessToken]);
+
+  function handleLogin(token: string, refreshToken: string) {
+    setCookies('accessToken', token, { path: '/' });
+    if (refreshToken) {
+      setCookies('refreshToken', refreshToken, { path: '/' });
+    }
+    setIsAuth(true);
   }
 
   function handleLogout() {
-    removeCookies('access_token', undefined, { path: '/' });
-    removeCookies('refresh_token', undefined, { path: '/' });
+    removeCookies('accessToken', { path: '/' });
+    removeCookies('refreshToken', { path: '/' });
     setIsAuth(false);
   }
 
   return {
     isAuth,
-    cookies,
     handleLogin,
     handleLogout,
   };

--- a/src/pages/googleCallback/index.tsx
+++ b/src/pages/googleCallback/index.tsx
@@ -24,8 +24,8 @@ export default function GoogleCallback() {
   useEffect(() => {
     if (data) {
       if (data.success) {
-        setCookie('access_token', data.tokens.access, { path: '/', secure: true, sameSite: 'lax', maxAge: 7200 });
-        setCookie('refresh_token', data.tokens.refresh, { path: '/', secure: true, sameSite: 'lax', maxAge: 7200 });
+        setCookie('accessToken', data.tokens.access, { path: '/', secure: true, sameSite: 'lax', maxAge: 7200 });
+        setCookie('refreshToken', data.tokens.refresh, { path: '/', secure: true, sameSite: 'lax', maxAge: 7200 });
         navigate('/my');
       } else {
         navigate('/login');

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -33,25 +33,27 @@ const onRejected = async (error: AxiosError | Error) => {
     if (error.response) {
       const { status } = error.response;
 
-      if (status === 401 && originalRequest && !originalRequest._retry) {
+      if (status === 401 && REFRESH_TOKEN !== 'undefined' && originalRequest && !originalRequest._retry) {
         originalRequest._retry = true;
+
         try {
           const response = await refreshToken({ REFRESH_TOKEN });
           const newAccessToken = response.data.access_token;
 
           if (document) {
-            document.cookie = `access_token=${newAccessToken}; path=/`;
+            document.cookie = `accessToken=${newAccessToken}; path=/`;
           }
 
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
           return authAxiosInstance(originalRequest);
         } catch (refreshError) {
+          console.error('Failed to refresh token:', refreshError);
           return Promise.reject(refreshError);
         }
       }
     }
   } else {
-    console.log(`error: ${error.message}`);
+    console.log(`Error: ${error.message}`);
   }
 
   return Promise.reject(error);

--- a/src/shared/lib/cookie.ts
+++ b/src/shared/lib/cookie.ts
@@ -10,5 +10,5 @@ function parseCookies() {
   return cookies;
 }
 
-export const getAccessToken = () => parseCookies()['access_token'];
-export const getRefreshToken = () => parseCookies()['refresh_token'];
+export const getAccessToken = () => parseCookies()['accessToken'];
+export const getRefreshToken = () => parseCookies()['refreshToken'];

--- a/src/shared/model/ModalContext.tsx
+++ b/src/shared/model/ModalContext.tsx
@@ -11,6 +11,7 @@ import { getWordpress, postWordpress } from '@/features/wordPress/api';
 import { DATE, HOUR, MINUTE } from '../config/constants/time';
 import Select from '@/shared/ui/Select/settingSelect';
 import { createSetting, getGptTopics, getSettingList } from '@/features/setting/api';
+import useAuth from '@/features/auth/model/useAuth';
 
 export type ModalType = 'wordpress' | 'coupang' | 'openai' | 'setting';
 
@@ -23,6 +24,8 @@ export interface ModalContext {
 export const ModalContext = createContext<ModalContext | undefined>(undefined);
 
 export function ModalProvider({ children }: Children) {
+  const { isAuth } = useAuth();
+
   const { isOpen, open, close, openModal } = useModalOpen();
   const [formData, setFormData] = useState({
     wordpress: {
@@ -200,10 +203,12 @@ export function ModalProvider({ children }: Children) {
   }, [gptTopics, gptTopicsLoading, gptTopicsExecute]);
 
   useEffect(() => {
-    fetchOpenaiData();
-    fetchCoupangData();
-    fetchWordpressData();
-    fetchGptTopics();
+    if (isAuth) {
+      fetchOpenaiData();
+      fetchCoupangData();
+      fetchWordpressData();
+      fetchGptTopics();
+    }
   }, [fetchOpenaiData, fetchCoupangData, fetchWordpressData, fetchGptTopics]);
 
   return (


### PR DESCRIPTION
## 문제 상황
- 비로그인 시 refreshToken 무한 요청
- 비로그인 시 ModalContext 내 useEffect에서 데이터 무한 요청
## 해결
- refreshToken 갱신 로직에 "!== undefined" 조건문 추가
- ModalContext 내 useEffect 내부 데이터 페칭 로직에 인증 조건문 추가