### PR TITLE
[FIX] 추가한 데이터 UI 업데이트 바로 안되는 이슈 개선

### DIFF
--- a/src/pages/my/index.tsx
+++ b/src/pages/my/index.tsx
@@ -4,7 +4,7 @@ import { userInfo } from '@/features/myInfo/api/userApi';
 import useFetch from '@/shared/model/useFetch';
 import Button from '@/shared/ui/Button';
 import Input from '@/shared/ui/Input';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import useModal from '@/shared/model/useModal';
 import Table from '@/shared/ui/Table';
 import { COUPANG_THEAD } from '@/features/coupangPartners/config/constants';
@@ -12,9 +12,17 @@ import { OPENAI_THEAD } from '@/features/openAi/config/constants';
 import { deleteOpenai, getOpenai } from '@/features/openAi/api';
 import { deleteWordpress, getWordpress } from '@/features/wordPress/api';
 import { WORDPRESS_THEAD } from '@/features/wordPress/config/constants';
+import { ModalContext } from '@/shared/model/ModalContext';
 
 export default function My() {
   const [isMyInfo, setIsMyInfo] = useState(true);
+  const modalContext = useContext(ModalContext);
+
+  if (!modalContext) {
+    throw new Error('ModalContext must be used within a ModalProvider');
+  }
+
+  const { formData } = modalContext;
 
   function clickToggleButton() {
     setIsMyInfo(prev => !prev);
@@ -48,7 +56,6 @@ export default function My() {
   });
 
   const { open } = useModal();
-
   const fetchUserData = useCallback(() => {
     if (!userInfoLoading && !userInfoData) {
       userInfoExecute();
@@ -118,6 +125,14 @@ export default function My() {
     fetchCoupangData();
     fetchWordpressData();
   }, [fetchUserData, fetchOpenaiData, fetchCoupangData, fetchWordpressData]);
+
+  useEffect(() => {
+    if (formData.coupang.api_key || formData.openai.api_key || formData.wordpress.name) {
+      coupangExecute();
+      openaiExecute();
+      wordpressExecute();
+    }
+  }, [formData]);
 
   return (
     <main className="flex justify-between px-20 py-20">

--- a/src/pages/setting/index.tsx
+++ b/src/pages/setting/index.tsx
@@ -2,13 +2,22 @@ import { getCoupangPartners } from '@/features/coupangPartners/api';
 import { getOpenai } from '@/features/openAi/api';
 import { deleteSetting, getGptTopics, getSettingList } from '@/features/setting/api';
 import { getWordpress } from '@/features/wordPress/api';
+import { ModalContext } from '@/shared/model/ModalContext';
 import useFetch from '@/shared/model/useFetch';
 import useModal from '@/shared/model/useModal';
 import Button from '@/shared/ui/Button';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useContext, useEffect } from 'react';
 
 export default function Setting() {
   const { open } = useModal();
+  const modalContext = useContext(ModalContext);
+
+  if (!modalContext) {
+    throw new Error('ModalContext must be used within a ModalProvider');
+  }
+
+  const { settingData } = modalContext;
+
   const { data: settingList, loading: settingLoading, execute: settingExecute } = useFetch(() => getSettingList());
   const fetchSettingList = useCallback(() => {
     if (!settingLoading && !settingList) {
@@ -70,6 +79,10 @@ export default function Setting() {
     fetchWordpressData();
     fetchGptTopics();
   }, [fetchSettingList, fetchCoupangData, fetchOpenaiData, fetchWordpressData, fetchGptTopics]);
+
+  useEffect(() => {
+    settingExecute();
+  }, [settingData]);
 
   return (
     <main className="flex flex-col p-10">

--- a/src/shared/model/ModalContext.tsx
+++ b/src/shared/model/ModalContext.tsx
@@ -15,10 +15,40 @@ import useAuth from '@/features/auth/model/useAuth';
 
 export type ModalType = 'wordpress' | 'coupang' | 'openai' | 'setting';
 
+export interface FormData {
+  wordpress: {
+    name: string;
+    password: string;
+    url: string;
+    nickname: string;
+  };
+  coupang: {
+    api_key: string;
+    api_secret: string;
+    nickname: string;
+  };
+  openai: {
+    api_key: string;
+    nickname: string;
+  };
+}
+
+export interface SettingData {
+  wordpress_id: number;
+  coupang_id: number;
+  gpt_id: number;
+  gpt_topic_id: number;
+  interval_days: number;
+  interval_hours: number;
+  interval_minutes: number;
+}
+
 export interface ModalContext {
   isOpen: (modalType: ModalType) => boolean;
   open: (modaltype: ModalType) => void;
   close: (modaltype: ModalType) => void;
+  formData: FormData;
+  settingData: SettingData;
 }
 
 export const ModalContext = createContext<ModalContext | undefined>(undefined);
@@ -27,7 +57,7 @@ export function ModalProvider({ children }: Children) {
   const { isAuth } = useAuth();
 
   const { isOpen, open, close, openModal } = useModalOpen();
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<FormData>({
     wordpress: {
       name: '',
       password: '',
@@ -44,7 +74,7 @@ export function ModalProvider({ children }: Children) {
       nickname: '',
     },
   });
-  const [settingData, setSettingData] = useState({
+  const [settingData, setSettingData] = useState<SettingData>({
     wordpress_id: 0,
     coupang_id: 0,
     gpt_id: 0,
@@ -166,8 +196,24 @@ export function ModalProvider({ children }: Children) {
           alert('값을 입력하세요.');
           return;
         }
+        if (currentModal === 'setting') {
+          setSettingData(prevData => ({
+            ...prevData,
+            ...settingData,
+          }));
+        }
         await postSetting();
         await settingListExecute();
+      }
+
+      if (currentModal !== 'setting') {
+        setFormData(prevData => ({
+          ...prevData,
+          [currentModal]: {
+            ...prevData[currentModal],
+            ...formData[currentModal],
+          },
+        }));
       }
 
       close();
@@ -212,7 +258,7 @@ export function ModalProvider({ children }: Children) {
   }, [fetchOpenaiData, fetchCoupangData, fetchWordpressData, fetchGptTopics]);
 
   return (
-    <ModalContext.Provider value={{ isOpen, open, close }}>
+    <ModalContext.Provider value={{ isOpen, open, close, formData, settingData }}>
       {children}
       {isOpen('setting') &&
         createPortal(

--- a/src/shared/model/ModalContext.tsx
+++ b/src/shared/model/ModalContext.tsx
@@ -196,25 +196,47 @@ export function ModalProvider({ children }: Children) {
           alert('값을 입력하세요.');
           return;
         }
+      }
+      const optimisticUpdate = async () => {
         if (currentModal === 'setting') {
+          const prevData = settingData;
+
           setSettingData(prevData => ({
             ...prevData,
             ...settingData,
           }));
-        }
-        await postSetting();
-        await settingListExecute();
-      }
 
-      if (currentModal !== 'setting') {
-        setFormData(prevData => ({
-          ...prevData,
-          [currentModal]: {
-            ...prevData[currentModal],
-            ...formData[currentModal],
-          },
-        }));
-      }
+          try {
+            await postSetting();
+            await settingListExecute();
+          } catch (error) {
+            setSettingData(prevData);
+            console.error('postSetting failed:', error);
+          }
+        }
+
+        if (currentModal !== 'setting') {
+          const prevData = formData;
+
+          setFormData(prevData => ({
+            ...prevData,
+            [currentModal]: {
+              ...prevData[currentModal],
+              ...formData[currentModal],
+            },
+          }));
+
+          try {
+            await postSetting();
+            await settingListExecute();
+          } catch (error) {
+            setFormData(prevData);
+            console.error('postSetting failed:', error);
+          }
+        }
+      };
+
+      optimisticUpdate();
 
       close();
       alert('처리가 완료되었습니다.');


### PR DESCRIPTION
## 문제

- my페이지와 setting 페이지에서 modal로 데이터를 post 요청 후 성공했을 때 페이지에 추가한 데이터 UI가 바로 업데이트 되지 않았습니다.

## 원인

- 데이터를 추가하는 post 요청 보내기 전 데이터 상태를 업데이트 하는 로직이 없었다. 이를 업데이트 하면 post 요청을 보내기 전 UI가 즉시 변경된다.
- 사용처에 ModalContext의 업데이트된 데이터가 동기화되지 않았다.

## 해결

- post 요청을 보내기 전에 데이터를 setter 함수로 바꾸는 로직을 추가했습니다.

```jsx
if (currentModal === 'setting') {
  setSettingData(prevData => ({
    ...prevData,
    ...settingData,
    }));
  }
 await postSetting();
 await settingListExecute();
```

- 사용처에서 useContext를 활용해 ModalContext의 데이터를 가져왔습니다.

```jsx
  const modalContext = useContext(ModalContext);

  if (!modalContext) {
    throw new Error('ModalContext must be used within a ModalProvider');
  }

  const { settingData } = modalContext;
```

## 최적화
**Optimistic Update 적용**

- UI를 먼저 업데이트
- 기존 상태를 저장하여 롤백 가능하게 함
- 요청 실패 시, 이전 상태로 복구
⇒ **이 방식으로 구현하면 서버 응답을 기다리지 않고도 즉시 UI가 변경되어 UX가 개선됨!**